### PR TITLE
fluentbit: JSON encoding: avoid base64 encoding of []byte inside other slices

### DIFF
--- a/cmd/fluent-bit/loki.go
+++ b/cmd/fluent-bit/loki.go
@@ -68,6 +68,26 @@ func (l *loki) sendRecord(r map[interface{}]interface{}, ts time.Time) error {
 	return l.client.Handle(lbs, ts, line)
 }
 
+// prevent base64-encoding []byte values (default json.Encoder rule) by
+// converting them to strings
+
+func toStringSlice(slice []interface{}) []interface{} {
+	var s []interface{}
+	for _, v := range slice {
+		switch t := v.(type) {
+		case []byte:
+			s = append(s, string(t))
+		case map[interface{}]interface{}:
+			s = append(s, toStringMap(t))
+		case []interface{}:
+			s = append(s, toStringSlice(t))
+		default:
+			s = append(s, t)
+		}
+	}
+	return s
+}
+
 func toStringMap(record map[interface{}]interface{}) map[string]interface{} {
 	m := make(map[string]interface{})
 	for k, v := range record {
@@ -77,10 +97,11 @@ func toStringMap(record map[interface{}]interface{}) map[string]interface{} {
 		}
 		switch t := v.(type) {
 		case []byte:
-			// prevent encoding to base64
 			m[key] = string(t)
 		case map[interface{}]interface{}:
 			m[key] = toStringMap(t)
+		case []interface{}:
+			m[key] = toStringSlice(t)
 		default:
 			m[key] = v
 		}

--- a/cmd/fluent-bit/loki_test.go
+++ b/cmd/fluent-bit/loki_test.go
@@ -224,6 +224,8 @@ func Test_toStringMap(t *testing.T) {
 	}{
 		{"already string", map[interface{}]interface{}{"string": "foo", "bar": []byte("buzz")}, map[string]interface{}{"string": "foo", "bar": "buzz"}},
 		{"skip non string", map[interface{}]interface{}{"string": "foo", 1.0: []byte("buzz")}, map[string]interface{}{"string": "foo"}},
+		{"byteslice in array", map[interface{}]interface{}{"string": "foo", "bar": []interface{}{map[interface{}]interface{}{"baz": []byte("quux")}}},
+			map[string]interface{}{"string": "foo", "bar": []interface{}{map[string]interface{}{"baz": "quux"}}}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Without this fix any strings inside arrays (directly or indirectly) end up being
base64-encoded.

**Which issue(s) this PR fixes**:
Fixes #1889

**Special notes for your reviewer**:

**Checklist**
- [X] Documentation added
- [X] Tests updated